### PR TITLE
OT-27: only retry connection errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jsforce 
+# jsforce
 
 Salesforce API Library for JavaScript applications (both on web browser and Node.js)
 
@@ -23,6 +23,14 @@ Supported Salesforce APIs are the following:
 - SOAP API
 - Streaming API
 - Tooling API
+
+### DNS Retries
+
+Due to numerous connection issues, we have implemented an automatic Network Error retry utilizing the [`requestreply`](https://github.com/FGRibreau/node-request-retry) package.
+
+As can be referenced in `lib/transport.js', we retry up to 2 times with a retry delay of 3500ms between each retry.
+
+This will improve our request reliability.
 
 ## Documentation
 

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -85,7 +85,7 @@ Transport.prototype.httpRequest = function(params, callback) {
         ...params,
         maxAttempts: 3,
         retryDelay: 3500,
-        retryStrategy: request.RetryStrategies.HTTPOrNetworkError
+        retryStrategy: request.RetryStrategies.NetworkError
       };
       req = httpRequest(opts, function(err, response) {
         if (err) {


### PR DESCRIPTION
To be more cautious about what we retry, we limit the retries to connection issues ONLY instead of any 500.

Since we are interacting with ALL HTTP methods in this spot, it is less risky.