### PR TITLE
OT 26 add dns timeouts

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -83,6 +83,7 @@ Transport.prototype.httpRequest = function(params, callback) {
     if (!req) {
       var opts = {
         ...params,
+        timeout: 2000,
         maxAttempts: 3,
         retryDelay: 3500,
         retryStrategy: request.RetryStrategies.NetworkError


### PR DESCRIPTION
Utilize the [`timeout`](https://github.com/request/request) option to tell request to time out if a connection isn't able to be made. Currently no timeout is set or defaulted to some value.